### PR TITLE
Exclude thirdparty libraries from LGTM scans

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,5 @@
+
+queries:
+  - exclude: Cytopia_ExternLibs
+  - exclude: Cytopia_Resources
+  - exclude: src\ThirdParty

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,5 +1,6 @@
 
-queries:
-  - exclude: Cytopia_ExternLibs
-  - exclude: Cytopia_Resources
-  - exclude: src\ThirdParty
+path_classifiers:
+  library:
+    - Cytopia_ExternLibs
+    - Cytopia_Resources
+    - src\ThirdParty

--- a/src/engine/uiManager.cxx
+++ b/src/engine/uiManager.cxx
@@ -11,7 +11,7 @@
 #include "../ThirdParty/json.hxx"
 
 using json = nlohmann::json;
-//DELME
+
 void UIManager::init()
 {
   json uiLayout;

--- a/src/engine/uiManager.cxx
+++ b/src/engine/uiManager.cxx
@@ -11,7 +11,7 @@
 #include "../ThirdParty/json.hxx"
 
 using json = nlohmann::json;
-
+//DELME
 void UIManager::init()
 {
   json uiLayout;


### PR DESCRIPTION
Fix LGTM Alert for third party libraries by excluding them