### PR TITLE
Fix SDL_mixer compile on macOS no Conan.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ project(
 # on macOS, usr/local/lib is not in the default search path for libraries. Homebrew install it's libraries there though.
 if (APPLE AND NOT USE_PACKAGE_MANAGER)
   LINK_DIRECTORIES(${LINK_DIRECTORIES} /usr/local/lib)
+  include_directories(${INCLUDE_DIRECTORIES} /usr/local/include/)
 endif()
 
 if (USE_PACKAGE_MANAGER)


### PR DESCRIPTION
Homebrew SDL2 headers under `/usr/local/include/SDL2/`.

Mimics d3b1141d84, just for headers instead of libraries. Allows me
to _`ENABLE_SDL2_MIXER`_.

Builds, runs, and passes tests.