### PR TITLE
🔧 Upgrade to pmm 1.4.1 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ TileDataEditor
 
 # ignore macOS stuff.
 .DS_Store
+_pmm

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,7 @@ matrix:
         - ninja package
 
       before_cache:
-        - rm -rf $HOME/.conan/data/qt/5.12.3/bincrafters/stable/build/ || true
-        - rm -rf $HOME/.conan/data/qt/5.12.3/bincrafters/stable/source/ || true
+        - cmake -P ../cmake/pmm.cmake /Conan /Clean
 
     # clang build
     - os:                linux
@@ -92,8 +91,7 @@ matrix:
         - ninja
 
       before_cache:
-        - rm -rf $HOME/.conan/data/qt/5.12.3/bincrafters/stable/build/ || true
-        - rm -rf $HOME/.conan/data/qt/5.12.3/bincrafters/stable/source/ || true
+        - cmake -P ../cmake/pmm.cmake /Conan /Clean
 
     - os:               osx
       name:             XCode 10.2 Build
@@ -116,8 +114,7 @@ matrix:
         - make package
 
       before_cache:
-        - rm -rf $HOME/.conan/data/qt/5.12.3/bincrafters/stable/build/ || true
-        - rm -rf $HOME/.conan/data/qt/5.12.3/bincrafters/stable/source/ || true
+        - cmake -P ../cmake/pmm.cmake /Conan /Clean
 
 deploy:
   provider:            pages

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,4 @@ deploy_script:
     scoop install https://raw.githubusercontent.com/AnotherFoxGuy/scoop-bucket/master/butler.json;
     butler push bin cytopia/cytopia:windows-ci --userversion $env:APPVEYOR_BUILD_VERSION;}
 on_success:
-- cmd: >-
-    RD /S /Q C:\Users\appveyor\.conan\data\sdl2_mixer\2.0.4\anotherfoxguy\stable\build\ & exit 0
-
-    RD /S /Q C:\Users\appveyor\.conan\data\sdl2_mixer\2.0.4\anotherfoxguy\stable\source\ & exit 0
+- cmd: cmake -P cmake/pmm.cmake /Conan /Clean

--- a/cmake/pmm.cmake
+++ b/cmake/pmm.cmake
@@ -21,7 +21,7 @@
 ## SOFTWARE.
 
 # Bump this version to change what PMM version is downloaded
-set(PMM_VERSION_INIT 1.4.0)
+set(PMM_VERSION_INIT 1.4.1)
 
 # Helpful macro to set a variable if it isn't already set
 macro(_pmm_set_if_undef varname)


### PR DESCRIPTION
PMM 1.4.1 adds the Clean command that removes temporary source and build folders in the local conan cache