### PR TITLE
fixed #179, changed EventManager timer list implementation.

### DIFF
--- a/src/engine/EventManager.cxx
+++ b/src/engine/EventManager.cxx
@@ -346,7 +346,7 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
 
   for (std::vector<Timer *>::iterator it = timers.begin(); it != timers.end();)
   {
-    if ((*it)->isActive())
+    if ( !(*it)->isActive())
     {
       it = timers.erase(it);
     }

--- a/src/engine/EventManager.cxx
+++ b/src/engine/EventManager.cxx
@@ -346,7 +346,7 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
 
   for (std::vector<Timer *>::iterator it = timers.begin(); it != timers.end();)
   {
-    if ((*it)->isTimedOut())
+    if ((*it)->isActive())
     {
       it = timers.erase(it);
     }

--- a/src/engine/EventManager.cxx
+++ b/src/engine/EventManager.cxx
@@ -139,9 +139,9 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
       {
         Camera::cameraOffset.x -= event.motion.xrel;
         Camera::cameraOffset.y -= event.motion.yrel;
-		
-		if (Engine::instance().map != nullptr)
-			Engine::instance().map->refresh();
+
+        if (Engine::instance().map != nullptr)
+          Engine::instance().map->refresh();
       }
       else if (engine.map != nullptr)
       {
@@ -265,7 +265,7 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
         }
         m_highlightedNodes.clear();
 
-		engine.map->unHighlightNode(m_highlitNode);
+        engine.map->unHighlightNode(m_highlitNode);
 
         break;
       }
@@ -340,18 +340,22 @@ void EventManager::checkEvents(SDL_Event &event, Engine &engine)
 
   for (auto &timer : timers)
   {
+    if (timer)
       timer->checkTimeout();
   }
 
-  for (auto &removedTimer : removedTimers)
+  for (std::vector<Timer *>::iterator it = timers.begin(); it != timers.end();)
   {
-      timers.erase(removedTimer);
+    if ((*it)->isTimedOut())
+    {
+      it = timers.erase(it);
+    }
+    else
+    {
+      ++it;
+    }
   }
-
-  removedTimers.clear();
-
 }
 
-void EventManager::registerTimer(Timer *timer) { timers.insert(timer); }
+void EventManager::registerTimer(Timer *timer) { timers.push_back(timer); }
 
-void EventManager::removeTimer(Timer *timer) { removedTimers.insert(timer); }

--- a/src/engine/EventManager.hxx
+++ b/src/engine/EventManager.hxx
@@ -22,7 +22,6 @@ public:
   void checkEvents(SDL_Event &event, Engine &engine);
 
   void registerTimer(Timer *timer);
-  void removeTimer(Timer *timer);
 
 private:
   UIManager &m_uiManager = UIManager::instance();
@@ -36,8 +35,7 @@ private:
   Point m_clickDownCoords = {0, 0, 0, 0};
   Point m_highlitNode = {0, 0, 0, 0};
   std::vector<Point> m_highlightedNodes = {};
-  std::set<Timer*> timers;
-  std::set<Timer*> removedTimers;
+  std::vector<Timer*> timers;
 };
 
 #endif

--- a/src/engine/basics/Timer.cxx
+++ b/src/engine/basics/Timer.cxx
@@ -6,7 +6,7 @@
 Timer::~Timer()
 {
     stop();
-    EventManager::instance().removeTimer(this);
+    //EventManager::instance().removeTimer(this);
 }
 
 void Timer::start()


### PR DESCRIPTION
no need for remove Timer,
when we iterate over timers in function EventManager::checkEvents  and checkout every timer.
we do another loop and check which timers got timeout and remove it ,
it is possible to remove elements from vector while iterating over  it using the method I used.
also used vector instead of set because set is immutable.
the method I used for removing elements is erase which the return value is 
"An iterator pointing to the new location of the element that followed the last element erased by the function call."
so by using   it = timers.erase(it),  it should point to the next element while removing the current.